### PR TITLE
Date unit functionality

### DIFF
--- a/script/main.js
+++ b/script/main.js
@@ -11,7 +11,7 @@
  * main.html?template=test_template
  *
  */
-const VERSION = '0.13.11';
+const VERSION = '0.13.12';
 const TEMPLATES = {
   'CanCOGeN Covid-19': {'folder': 'canada_covid19', 'status': 'published'},
   'PHAC Dexa (ALPHA)': {'folder': 'phac_dexa', 'status': 'draft'},
@@ -803,6 +803,16 @@ const fieldChangeRules = (change, fields, triggered_changes) => {
 
 };
 
+/**
+ * Adjust given dateString date to match year or month granularity given by
+ * dateGranularity parameter. If month unit required but not supplied, then
+ * a yyyy-__-01 will be supplied to indicate that month needs attention.
+ *
+ * @param {String} dateGranularity, either 'year' or 'month'
+ * @param {String} ISO 8601 date string or leading part, possibly just YYYY or
+                   YYYY-MM
+ * @return {String} ISO 8601 date string.
+ */
 const setDateChange = (dateGranularity, dateString) => {
 
   var dateParts = dateString.split('-');
@@ -871,7 +881,7 @@ const binChangeTest = (matrix, rowOffset, col, fields, binOffset, triggered_chan
           //}
 
         }
-        // .flatVocabulary is an array of bin ranges e.g. "10 - 19"
+        // .flatVocabulary is an array of string bin ranges e.g. "10 - 19"
         for (const number_range of fields[col+binOffset].flatVocabulary) {
           // ParseInt just looks at first part of number 
           if (number >= parseFloat(number_range)) {

--- a/template/canada_covid19/data.js
+++ b/template/canada_covid19/data.js
@@ -388,6 +388,32 @@ var DATA = [
         }
       },
       {
+        "fieldName": "sample collection date unit",
+        "capitalize": "",
+        "ontology_id": "",
+        "datatype": "select",
+        "source": "",
+        "dataStatus": [
+          "Not Applicable",
+          "Missing",
+          "Not Collected",
+          "Not Provided",
+          "Restricted Access"
+        ],
+        "xs:minInclusive": "",
+        "xs:maxInclusive": "",
+        "requirement": "required",
+        "description": "Granularity of collection date - year or month or day",
+        "guidance": "",
+        "examples": "year",
+        "exportField": {},
+        "vocabulary": {
+          "year": {},
+          "month": {},
+          "day": {}
+        }
+      },
+      {
         "fieldName": "sample received date",
         "capitalize": "",
         "ontology_id": "",

--- a/template/canada_covid19/data.js
+++ b/template/canada_covid19/data.js
@@ -388,32 +388,6 @@ var DATA = [
         }
       },
       {
-        "fieldName": "sample collection date unit",
-        "capitalize": "",
-        "ontology_id": "",
-        "datatype": "select",
-        "source": "",
-        "dataStatus": [
-          "Not Applicable",
-          "Missing",
-          "Not Collected",
-          "Not Provided",
-          "Restricted Access"
-        ],
-        "xs:minInclusive": "",
-        "xs:maxInclusive": "",
-        "requirement": "required",
-        "description": "Granularity of collection date - year or month or day",
-        "guidance": "",
-        "examples": "year",
-        "exportField": {},
-        "vocabulary": {
-          "year": {},
-          "month": {},
-          "day": {}
-        }
-      },
-      {
         "fieldName": "sample received date",
         "capitalize": "",
         "ontology_id": "",


### PR DESCRIPTION
This extension allows any two consecutive fields, a [xs:date] followed by a [select] field which supplies units of "year", "month", or "day", to work together to convert the date entry to a yyyy-mm-dd (day) or yyyy-mm-01 (month) or yyyy-01-01 (year) entry.  Effectively binning dates at the given resolution.