### PR TITLE
Fix RuleDB.SPECIES null value issue

### DIFF
--- a/template/phac_dexa/export.js
+++ b/template/phac_dexa/export.js
@@ -241,7 +241,8 @@ var setRuleDB = (dataRow, sourceFields, sourceFieldNameMap, normalize, preserveC
     case 'food' : {
       // species-> food product
       // Issue, sometimes species = "Other" ????
-      RuleDB.food_product = RuleDB.SPECIES;
+      if (RuleDB.SPECIES)
+        RuleDB.food_product = RuleDB.SPECIES;
       RuleDB['host (common name)'] = null; //wHY ISNT THIS WORKING???
 
       if (RuleDB.SUBJECT_DESCRIPTIONS)
@@ -262,6 +263,7 @@ var setRuleDB = (dataRow, sourceFields, sourceFieldNameMap, normalize, preserveC
       if (merged in normalize) {
       	RuleDB.food_product = normalize[merged].label;
       }
+
       break; // prevents advancing to blank/UNKNOWN
     };
 


### PR DESCRIPTION
A null value was getting inserted into RuleDB.food_product variable, causing downstream function errors.