### PR TITLE
Revert "Make header check more robust"

### DIFF
--- a/script/main.js
+++ b/script/main.js
@@ -610,39 +610,14 @@ const updateSheetRange = (worksheet) => {
  * recognized.
  */
 const compareMatrixHeadersToGrid = (matrix, data) => {
-  let headerRow = 0;
-  const columnHeaders = getFlatHeaders(data)[1];
-  const fileFirstRow = matrix[0];
-  const fileSecondRow = matrix[1];
-  if (headersAreEqual(columnHeaders, fileFirstRow)) {
-    headerRow = 1;
-  } else if (headersAreEqual(columnHeaders, fileSecondRow)) {
-    headerRow = 2;
-  }
-  return headerRow
-};
-
-/**
- * Determine if an array of Strings that represent the header, are equal
- * to a given array of Strings. This check removes all whitespace, and lowers
- * the String before performing the equality check.
- * @param {Array<String>} headerArrOne
- * @param {Array<String>} headerArrTwo
- * @return {Boolean} Returns True if both arrays have equal values, False if not.
- */
-const headersAreEqual = (headerArrOne, headerArrTwo) => {
-  const headerOneTrimmed = headerArrOne.map((str) =>
-    str.toLowerCase().replace(/\s/g, "")
-  );
-  const headerTwoTrimmed = headerArrTwo.map((str) =>
-    str.toLowerCase().replace(/\s/g, "")
-  );
-  return (
-    Array.isArray(headerOneTrimmed) &&
-    Array.isArray(headerTwoTrimmed) &&
-    headerOneTrimmed.length === headerTwoTrimmed.length &&
-    headerOneTrimmed.every((val, index) => val === headerTwoTrimmed[index])
-  );
+  const expectedSecondRow = getFlatHeaders(data)[1];
+  const actualFirstRow = matrix[0];
+  const actualSecondRow = matrix[1];
+  if (JSON.stringify(expectedSecondRow) === JSON.stringify(actualFirstRow))
+    return 1;
+  if (JSON.stringify(expectedSecondRow) === JSON.stringify(actualSecondRow))
+    return 2;
+  return false;
 };
 
 /**


### PR DESCRIPTION
Reverts Public-Health-Bioinformatics/DataHarmonizer#196

On the surface this seems to avoid miss-match on fields with extra spaces in labels.  But the algorithm for aligning data columns to template still must run - and it currently depends on exact string match.  See main.js mapMatrixToGrid function unmappedHeaders code.  So that code needs to be changed too, otherwise each space-mismatched header column of info won't be uploaded.

(Note that consequently the template's normalized field names, not the user's uploaded field with extra spaces, will be used when saving the data).
