### PR TITLE
Add null value choices to multiselects

### DIFF
--- a/script/main.js
+++ b/script/main.js
@@ -11,7 +11,7 @@
  * main.html?template=test_template
  *
  */
-const VERSION = '0.13.32';
+const VERSION = '0.13.33';
 const VERSION_TEXT = 'DataHarmonizer provenance: v' + VERSION;
 const TEMPLATES = {
   'CanCOGeN Covid-19': {'folder': 'canada_covid19', 'status': 'published'},
@@ -320,6 +320,7 @@ const getColumns = (data) => {
         col.editor = 'text';
         col.renderer = 'autocomplete';
         col.source = field.flatVocabulary;
+        if (field.dataStatus) col.source.push(...field.dataStatus);
         break;
     }
     ret.push(col);


### PR DESCRIPTION
While single-select menus were displaying null value dataStatus choices, the multiselect lists were not.  This is fixed.  They get validated too.  Issue #191 